### PR TITLE
Point admin login link at findmusicians.co.uk

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,7 @@ function App() {
                 <a href="https://instagram.com/ambastrings">@ambastrings</a>
               </li>
               <li>
-                <a target="_blank" href="https://app.groovetech.co.uk/admin">
+                <a target="_blank" href="https://findmusicians.co.uk/admin">
                   Login
                 </a>
               </li>


### PR DESCRIPTION
## Why

`app.groovetech.co.uk` is being retired as part of the groove-app API-first cutover. The CMS admin now lives at `findmusicians.co.uk/admin` (Cloud Run behind the Cloudflare Worker).

## What

One line: the footer **Login** link in `App.tsx` now points at `https://findmusicians.co.uk/admin`.

## Related (already done outside this PR)

- `VITE_BASE_API_URL` updated to `https://api.findmusicians.co.uk` in all Vercel environments and production redeployed — the app already consumes the new edge API (same response shapes, no code change needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CPdLJHXt9vUEi3ZJABo4g